### PR TITLE
Add default props to NetworkSettingsScreen component

### DIFF
--- a/app/screens/NetworkSettingsScreen/index.js
+++ b/app/screens/NetworkSettingsScreen/index.js
@@ -179,6 +179,13 @@ NetworkSettingsScreen.propTypes = {
   onSavePress: PropTypes.func
 }
 
+NetworkSettingsScreen.defaultProps = {
+  settings: {
+    network: {},
+    service: { foreground: false }
+  }
+}
+
 function select(store) {
   return {
     settings: store.app.endpointSettings

--- a/app/screens/NetworkSettingsScreen/index.js
+++ b/app/screens/NetworkSettingsScreen/index.js
@@ -11,7 +11,7 @@ import ListCheckbox from '../../components/common/ListCheckbox'
 
 import cs from '../../assets/styles/containers'
 
-class MediaSettingsScreen extends Component {
+class NetworkSettingsScreen extends Component {
 
   constructor(props) {
     super(props)
@@ -168,7 +168,7 @@ class MediaSettingsScreen extends Component {
   }
 }
 
-MediaSettingsScreen.propTypes = {
+NetworkSettingsScreen.propTypes = {
   settings: PropTypes.shape({
     network: PropTypes.object,
     service: PropTypes.shape({
@@ -196,4 +196,4 @@ function actions(dispatch) {
   }
 }
 
-export default connect(select, actions)(MediaSettingsScreen)
+export default connect(select, actions)(NetworkSettingsScreen)


### PR DESCRIPTION
User with no account generates an error if they click on Network on settings screen.

Also renamed the NetworkSettingsScreen component.